### PR TITLE
spelling correction

### DIFF
--- a/radix.cpp
+++ b/radix.cpp
@@ -16,7 +16,7 @@ class queue{
      
      void enqueue(int x){
           if(filled == size){
-               cout << "Queue exced the size " <<endl;
+               cout << "Queue exceed the size " <<endl;
           }
           else{
                if(rear==size-1){


### PR DESCRIPTION
exced corrected to exceed